### PR TITLE
Support Swift 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.7
 
 //
 // This source file is part of the CardinalKit open-source project
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "CardinalKitOnboarding", targets: ["CardinalKitOnboarding"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordBDHG/CardinalKitViews", .upToNextMinor(from: "0.2.0"))
+        .package(url: "https://github.com/StanfordBDHG/CardinalKitViews", .upToNextMinor(from: "0.2.1"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Support Swift 5.7

## :recycle: Current situation & Problem
- As GitHub Actions don't currently support macOS 13 Ventura (https://github.com/github/roadmap/issues/620), we can not use Xcode 14.3 on the GitHub Action Runners. Therefore we need to continue supporting Swift 5.7 for now.

## :bulb: Proposed solution
- Adds support for Swift 5.7.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

